### PR TITLE
[codex] add httpx browser navigation sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **gcommon** (1485 symbols, 3030 relationships, 80 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **gcommon** (1495 symbols, 2976 relationships, 80 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **gcommon** (1485 symbols, 3030 relationships, 80 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **gcommon** (1495 symbols, 2976 relationships, 80 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/docs/superpowers/plans/2026-05-06-httpx-browser-navigation.md
+++ b/docs/superpowers/plans/2026-05-06-httpx-browser-navigation.md
@@ -1,0 +1,989 @@
+# httpx Browser Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a generic browser navigation layer to `httpx.Client` so caller-owned clients can maintain `Referer`, `Origin`, `Sec-Fetch-*`, and HTML/XHR headers across a sequential browser-like session.
+
+**Architecture:** Keep browser fingerprinting in `WithBrowser(...)` and add `WithBrowserNavigation(...)` as a per-client profile option. Each `NewClient` gets a fresh navigation state; `Client.Clone()` shares that state through req wrapper closures. Capture request-explicit headers before req merges common headers, then apply dynamic headers in the client round-trip wrapper after URL/body parsing and before transport send.
+
+**Tech Stack:** Go 1.25, `github.com/imroc/req/v3`, `net/http`, `net/url`, `sync`, `net/http/httptest`, GitNexus.
+
+---
+
+## Spec
+
+Use `docs/superpowers/specs/2026-05-06-httpx-browser-navigation.md` as the source of truth. `httpx.md` remains the requirements input and should not be edited unless the user explicitly asks to revise requirements.
+
+## File Map
+
+- Create: `httpx/browser_navigation.go`
+  - Public navigation options, `ReferrerPolicy`, request kind API, stateful wrapper installation, header computation helpers.
+- Create: `httpx/browser_navigation_test.go`
+  - End-to-end header behavior tests with `httptest`.
+- Modify: `httpx/client_options.go`
+  - Add `browserNavigation *browserNavigationConfig` to `clientRegisterOpts`.
+  - Deep-copy the config in `clone()`.
+- Modify: `httpx/factory.go`
+  - Install navigation on each created req client after request interceptors and before logging/response hooks return.
+- Modify: `httpx/client.go`
+  - Keep `Clone()` behavior; add no public state fields. The clone sharing behavior comes from req copying wrapper closures.
+- Modify: `httpx/doc.go`
+  - Mention browser navigation and the request hook/round-trip ordering.
+- Modify: `httpx/README.md`
+  - Document public API, header precedence, clone/session semantics, and browser session example.
+
+## GitNexus Controls
+
+Pre-plan impact baseline already returned LOW risk for:
+
+- `Client`
+- `Client.Clone`
+- `ClientFactory.buildReqClient`
+- `clientRegisterOpts`
+- `applyBrowserProfile`
+
+Before implementation edits, rerun impact for any symbol being modified:
+
+```text
+impact(repo: "gcommon", target: "Client", file_path: "httpx/client.go", kind: "Struct", direction: "upstream")
+impact(repo: "gcommon", target: "Clone", file_path: "httpx/client.go", kind: "Method", direction: "upstream")
+impact(repo: "gcommon", target: "buildReqClient", file_path: "httpx/factory.go", kind: "Method", direction: "upstream")
+impact(repo: "gcommon", target: "clientRegisterOpts", file_path: "httpx/client_options.go", kind: "Struct", direction: "upstream")
+impact(repo: "gcommon", target: "applyBrowserProfile", file_path: "httpx/browser.go", kind: "Function", direction: "upstream")
+```
+
+If any result is HIGH or CRITICAL, stop and report direct callers, affected processes, and risk before editing. Before any commit, run:
+
+```text
+detect_changes(repo: "gcommon", scope: "all")
+```
+
+## Task 1: Add Public API Tests
+
+**Files:**
+- Create: `httpx/browser_navigation_test.go`
+
+- [ ] **Step 1: Add tests for first request, same-origin, cross-site, POST origin, and HTML defaults**
+
+Create `httpx/browser_navigation_test.go` with:
+
+```go
+package httpx_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/c1emon/gcommon/httpx/v2"
+)
+
+type seenNavigationHeaders struct {
+	Accept                   string `json:"accept"`
+	Referer                  string `json:"referer"`
+	Origin                   string `json:"origin"`
+	SecFetchSite             string `json:"secFetchSite"`
+	SecFetchMode             string `json:"secFetchMode"`
+	SecFetchDest             string `json:"secFetchDest"`
+	SecFetchUser             string `json:"secFetchUser"`
+	UpgradeInsecureRequests string `json:"upgradeInsecureRequests"`
+	XRequestedWith           string `json:"xRequestedWith"`
+}
+
+func navigationRecorder(t *testing.T) (*httptest.Server, *[]seenNavigationHeaders) {
+	t.Helper()
+	var seen []seenNavigationHeaders
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := seenNavigationHeaders{
+			Accept:                   r.Header.Get("Accept"),
+			Referer:                  r.Header.Get("Referer"),
+			Origin:                   r.Header.Get("Origin"),
+			SecFetchSite:             r.Header.Get("Sec-Fetch-Site"),
+			SecFetchMode:             r.Header.Get("Sec-Fetch-Mode"),
+			SecFetchDest:             r.Header.Get("Sec-Fetch-Dest"),
+			SecFetchUser:             r.Header.Get("Sec-Fetch-User"),
+			UpgradeInsecureRequests: r.Header.Get("Upgrade-Insecure-Requests"),
+			XRequestedWith:           r.Header.Get("X-Requested-With"),
+		}
+		seen = append(seen, h)
+		_ = json.NewEncoder(w).Encode(h)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &seen
+}
+
+func TestBrowserNavigation_firstAndSameOriginNavigationHeaders(t *testing.T) {
+	srv, seen := navigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(srv.URL),
+		httpx.WithBrowserNavigation(),
+	)
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().Get("/login?next=%2Fhome"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Req().Get("/home"); err != nil {
+		t.Fatal(err)
+	}
+
+	first := (*seen)[0]
+	if first.SecFetchSite != "none" {
+		t.Fatalf("first Sec-Fetch-Site: want none, got %q", first.SecFetchSite)
+	}
+	if first.Referer != "" {
+		t.Fatalf("first Referer: want empty, got %q", first.Referer)
+	}
+	if first.SecFetchMode != "navigate" || first.SecFetchDest != "document" || first.SecFetchUser != "?1" {
+		t.Fatalf("first navigation headers: %+v", first)
+	}
+	if first.UpgradeInsecureRequests != "1" {
+		t.Fatalf("first Upgrade-Insecure-Requests: want 1, got %q", first.UpgradeInsecureRequests)
+	}
+
+	second := (*seen)[1]
+	if second.SecFetchSite != "same-origin" {
+		t.Fatalf("second Sec-Fetch-Site: want same-origin, got %q", second.SecFetchSite)
+	}
+	wantReferer := srv.URL + "/login?next=%2Fhome"
+	if second.Referer != wantReferer {
+		t.Fatalf("second Referer: want %q, got %q", wantReferer, second.Referer)
+	}
+}
+
+func TestBrowserNavigation_crossOriginRefererUsesOrigin(t *testing.T) {
+	first, _ := navigationRecorder(t)
+	second, seenSecond := navigationRecorder(t)
+
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser", httpx.WithBrowserNavigation())
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().Get(first.URL + "/start?ticket=abc"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Req().Get(second.URL + "/next"); err != nil {
+		t.Fatal(err)
+	}
+
+	got := (*seenSecond)[0]
+	if got.SecFetchSite != "cross-site" {
+		t.Fatalf("Sec-Fetch-Site: want cross-site, got %q", got.SecFetchSite)
+	}
+	if got.Referer != first.URL+"/" {
+		t.Fatalf("Referer: want %q, got %q", first.URL+"/", got.Referer)
+	}
+}
+
+func TestBrowserNavigation_postAddsCurrentOrigin(t *testing.T) {
+	srv, seen := navigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser", httpx.WithBaseURL(srv.URL), httpx.WithBrowserNavigation())
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().Post("/submit"); err != nil {
+		t.Fatal(err)
+	}
+	if (*seen)[0].Origin != srv.URL {
+		t.Fatalf("Origin: want %q, got %q", srv.URL, (*seen)[0].Origin)
+	}
+}
+```
+
+- [ ] **Step 2: Run the focused tests and confirm they fail**
+
+Run:
+
+```bash
+go test ./httpx -run BrowserNavigation -count=1
+```
+
+Expected: build fails because `WithBrowserNavigation` does not exist.
+
+## Task 2: Add API Types And Option Storage
+
+**Files:**
+- Create: `httpx/browser_navigation.go`
+- Modify: `httpx/client_options.go`
+
+- [ ] **Step 1: Add public API and config types**
+
+Create `httpx/browser_navigation.go` with this initial content:
+
+```go
+package httpx
+
+import (
+	"net/url"
+	"sync"
+
+	"github.com/c1emon/gcommon/v2/util"
+)
+
+type BrowserNavigationOption util.Option[browserNavigationConfig]
+
+type ReferrerPolicy string
+
+const (
+	ReferrerPolicyNoReferrer                  ReferrerPolicy = "no-referrer"
+	ReferrerPolicyOrigin                      ReferrerPolicy = "origin"
+	ReferrerPolicyStrictOriginWhenCrossOrigin ReferrerPolicy = "strict-origin-when-cross-origin"
+)
+
+type BrowserRequestKind int
+
+const (
+	BrowserRequestAuto BrowserRequestKind = iota
+	BrowserRequestNavigation
+	BrowserRequestXHR
+)
+
+const browserRequestKindHeader = "X-Httpx-Browser-Request-Kind"
+
+type browserNavigationConfig struct {
+	referrerPolicy        ReferrerPolicy
+	xhrForJSON            bool
+	defaultXRequestedWith bool
+	defaultSecFetchUser   bool
+}
+
+type browserNavigationState struct {
+	mu      sync.Mutex
+	lastURL *url.URL
+}
+
+func defaultBrowserNavigationConfig() *browserNavigationConfig {
+	return &browserNavigationConfig{
+		referrerPolicy:        ReferrerPolicyStrictOriginWhenCrossOrigin,
+		xhrForJSON:            true,
+		defaultXRequestedWith: false,
+		defaultSecFetchUser:   true,
+	}
+}
+
+func (c *browserNavigationConfig) clone() *browserNavigationConfig {
+	if c == nil {
+		return nil
+	}
+	out := *c
+	return &out
+}
+
+func WithBrowserNavigation(opts ...BrowserNavigationOption) ClientOption {
+	return util.WrapFuncOption(func(o *clientRegisterOpts) {
+		cfg := defaultBrowserNavigationConfig()
+		for _, opt := range opts {
+			opt.Apply(cfg)
+		}
+		o.browserNavigation = cfg
+	})
+}
+
+func WithReferrerPolicy(policy ReferrerPolicy) BrowserNavigationOption {
+	return util.WrapFuncOption(func(c *browserNavigationConfig) {
+		if policy != "" {
+			c.referrerPolicy = policy
+		}
+	})
+}
+
+func WithXHRForJSON(enabled bool) BrowserNavigationOption {
+	return util.WrapFuncOption(func(c *browserNavigationConfig) {
+		c.xhrForJSON = enabled
+	})
+}
+
+func WithDefaultXRequestedWith(enabled bool) BrowserNavigationOption {
+	return util.WrapFuncOption(func(c *browserNavigationConfig) {
+		c.defaultXRequestedWith = enabled
+	})
+}
+
+func WithDefaultSecFetchUser(enabled bool) BrowserNavigationOption {
+	return util.WrapFuncOption(func(c *browserNavigationConfig) {
+		c.defaultSecFetchUser = enabled
+	})
+}
+
+func (r *Request) WithBrowserRequestKind(kind BrowserRequestKind) *Request {
+	if r == nil || r.Request == nil {
+		return r
+	}
+	switch kind {
+	case BrowserRequestNavigation:
+		r.SetHeader(browserRequestKindHeader, "navigation")
+	case BrowserRequestXHR:
+		r.SetHeader(browserRequestKindHeader, "xhr")
+	default:
+		r.SetHeader(browserRequestKindHeader, "auto")
+	}
+	return r
+}
+
+func (r *Request) AsXHR() *Request {
+	return r.WithBrowserRequestKind(BrowserRequestXHR)
+}
+
+func (r *Request) AsNavigation() *Request {
+	return r.WithBrowserRequestKind(BrowserRequestNavigation)
+}
+```
+
+- [ ] **Step 2: Store config on client registration options**
+
+In `httpx/client_options.go`, add this field to `clientRegisterOpts`:
+
+```go
+browserNavigation *browserNavigationConfig
+```
+
+In `func (o clientRegisterOpts) clone() clientRegisterOpts`, add:
+
+```go
+out.browserNavigation = o.browserNavigation.clone()
+```
+
+- [ ] **Step 3: Run tests and confirm API compiles but behavior is missing**
+
+Run:
+
+```bash
+go test ./httpx -run BrowserNavigation -count=1
+```
+
+Expected: tests fail at runtime because no navigation wrapper is installed yet.
+
+## Task 3: Implement Header Computation Helpers
+
+**Files:**
+- Modify: `httpx/browser_navigation.go`
+
+- [ ] **Step 1: Add helper unit tests for request kind and referrer policy**
+
+Append to `httpx/browser_navigation_test.go`:
+
+```go
+func TestBrowserNavigation_jsonDefaultsToXHR(t *testing.T) {
+	srv, seen := navigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser", httpx.WithBaseURL(srv.URL), httpx.WithBrowserNavigation())
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().SetBodyJsonMarshal(map[string]string{"hello": "world"}).Post("/api"); err != nil {
+		t.Fatal(err)
+	}
+	got := (*seen)[0]
+	if got.Accept != "application/json, text/plain, */*" {
+		t.Fatalf("Accept: want JSON accept, got %q", got.Accept)
+	}
+	if got.SecFetchMode != "cors" || got.SecFetchDest != "empty" {
+		t.Fatalf("XHR fetch headers: %+v", got)
+	}
+	if got.SecFetchUser != "" || got.UpgradeInsecureRequests != "" {
+		t.Fatalf("XHR should not include navigation-only headers: %+v", got)
+	}
+}
+
+func TestBrowserNavigation_explicitRequestKindOverridesContentType(t *testing.T) {
+	srv, seen := navigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser", httpx.WithBaseURL(srv.URL), httpx.WithBrowserNavigation())
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().AsNavigation().SetBodyJsonMarshal(map[string]string{"hello": "world"}).Post("/form"); err != nil {
+		t.Fatal(err)
+	}
+	got := (*seen)[0]
+	if got.SecFetchMode != "navigate" || got.SecFetchDest != "document" {
+		t.Fatalf("explicit navigation should win over JSON content type: %+v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Add helper functions**
+
+Add `net/http` and `strings` to the import list in `httpx/browser_navigation.go`.
+
+Append these helpers to `httpx/browser_navigation.go`:
+
+```go
+func sameOrigin(a, b *url.URL) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return strings.EqualFold(a.Scheme, b.Scheme) && strings.EqualFold(a.Host, b.Host)
+}
+
+func originString(u *url.URL) string {
+	if u == nil || u.Scheme == "" || u.Host == "" {
+		return ""
+	}
+	return u.Scheme + "://" + u.Host
+}
+
+func originReferer(u *url.URL) string {
+	if o := originString(u); o != "" {
+		return o + "/"
+	}
+	return ""
+}
+
+func cloneURL(u *url.URL) *url.URL {
+	if u == nil {
+		return nil
+	}
+	out := *u
+	return &out
+}
+
+func explicitHeaderKeys(h http.Header) map[string]struct{} {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(h))
+	for k := range h {
+		out[http.CanonicalHeaderKey(k)] = struct{}{}
+	}
+	delete(out, http.CanonicalHeaderKey(browserRequestKindHeader))
+	return out
+}
+
+func hasExplicitHeader(explicit map[string]struct{}, key string) bool {
+	_, ok := explicit[http.CanonicalHeaderKey(key)]
+	return ok
+}
+
+func setDynamicHeader(h http.Header, explicit map[string]struct{}, key, value string) {
+	if value == "" || hasExplicitHeader(explicit, key) {
+		return
+	}
+	h.Set(key, value)
+}
+
+func browserRequestKindFromHeader(h http.Header) BrowserRequestKind {
+	switch strings.ToLower(h.Get(browserRequestKindHeader)) {
+	case "navigation":
+		return BrowserRequestNavigation
+	case "xhr":
+		return BrowserRequestXHR
+	default:
+		return BrowserRequestAuto
+	}
+}
+
+func isJSONContentType(ct string) bool {
+	ct = strings.ToLower(strings.TrimSpace(ct))
+	return ct == "application/json" || strings.HasPrefix(ct, "application/json;")
+}
+
+func (c *browserNavigationConfig) effectiveRequestKind(h http.Header) BrowserRequestKind {
+	switch browserRequestKindFromHeader(h) {
+	case BrowserRequestNavigation:
+		return BrowserRequestNavigation
+	case BrowserRequestXHR:
+		return BrowserRequestXHR
+	}
+	if c.xhrForJSON && isJSONContentType(h.Get("Content-Type")) {
+		return BrowserRequestXHR
+	}
+	return BrowserRequestNavigation
+}
+
+func (c *browserNavigationConfig) refererFor(prev, current *url.URL) string {
+	if prev == nil {
+		return ""
+	}
+	switch c.referrerPolicy {
+	case ReferrerPolicyNoReferrer:
+		return ""
+	case ReferrerPolicyOrigin:
+		return originReferer(prev)
+	case ReferrerPolicyStrictOriginWhenCrossOrigin, "":
+		if sameOrigin(prev, current) {
+			return prev.String()
+		}
+		return originReferer(prev)
+	default:
+		if sameOrigin(prev, current) {
+			return prev.String()
+		}
+		return originReferer(prev)
+	}
+}
+
+func secFetchSite(prev, current *url.URL) string {
+	if prev == nil {
+		return "none"
+	}
+	if sameOrigin(prev, current) {
+		return "same-origin"
+	}
+	return "cross-site"
+}
+```
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+go test ./httpx -run BrowserNavigation -count=1
+```
+
+Expected: tests still fail until the wrapper applies helpers.
+
+## Task 4: Install Navigation Wrapper
+
+**Files:**
+- Modify: `httpx/browser_navigation.go`
+- Modify: `httpx/factory.go`
+
+- [ ] **Step 1: Add explicit-header capture and round-trip application**
+
+Append to `httpx/browser_navigation.go`:
+
+```go
+const (
+	htmlAccept = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
+	jsonAccept = "application/json, text/plain, */*"
+)
+
+type explicitHeadersKey struct{}
+
+func installBrowserNavigation(c *req.Client, cfg *browserNavigationConfig) {
+	if c == nil || cfg == nil {
+		return
+	}
+	state := &browserNavigationState{}
+
+	c.OnBeforeRequest(func(_ *req.Client, r *req.Request) error {
+		if r == nil {
+			return nil
+		}
+		r.SetContext(contextWithExplicitHeaders(r.Context(), explicitHeaderKeys(r.Headers)))
+		return nil
+	})
+
+	c.WrapRoundTripFunc(func(rt req.RoundTripper) req.RoundTripFunc {
+		return func(r *req.Request) (*req.Response, error) {
+			if r == nil {
+				return rt.RoundTrip(r)
+			}
+			explicit := explicitHeadersFromContext(r.Context())
+			state.apply(cfg, r, explicit)
+			resp, err := rt.RoundTrip(r)
+			if resp != nil && resp.Response != nil && resp.Response.Request != nil {
+				state.remember(resp.Response.Request.URL)
+			}
+			return resp, err
+		}
+	})
+}
+
+func contextWithExplicitHeaders(ctx context.Context, explicit map[string]struct{}) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, explicitHeadersKey{}, explicit)
+}
+
+func explicitHeadersFromContext(ctx context.Context) map[string]struct{} {
+	if ctx == nil {
+		return nil
+	}
+	explicit, _ := ctx.Value(explicitHeadersKey{}).(map[string]struct{})
+	return explicit
+}
+
+func (s *browserNavigationState) remember(u *url.URL) {
+	if s == nil || u == nil {
+		return
+	}
+	s.mu.Lock()
+	s.lastURL = cloneURL(u)
+	s.mu.Unlock()
+}
+
+func (s *browserNavigationState) previous() *url.URL {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return cloneURL(s.lastURL)
+}
+
+func (s *browserNavigationState) apply(cfg *browserNavigationConfig, r *req.Request, explicit map[string]struct{}) {
+	if s == nil || cfg == nil || r == nil || r.URL == nil {
+		return
+	}
+	h := r.Headers
+	if h == nil {
+		h = make(http.Header)
+		r.Headers = h
+	}
+	current := r.URL
+	prev := s.previous()
+
+	setDynamicHeader(h, explicit, "Referer", cfg.refererFor(prev, current))
+	setDynamicHeader(h, explicit, "Sec-Fetch-Site", secFetchSite(prev, current))
+	if strings.EqualFold(r.Method, http.MethodPost) {
+		setDynamicHeader(h, explicit, "Origin", originString(current))
+	}
+
+	switch cfg.effectiveRequestKind(h) {
+	case BrowserRequestXHR:
+		setDynamicHeader(h, explicit, "Accept", jsonAccept)
+		setDynamicHeader(h, explicit, "Sec-Fetch-Mode", "cors")
+		setDynamicHeader(h, explicit, "Sec-Fetch-Dest", "empty")
+		if cfg.defaultXRequestedWith {
+			setDynamicHeader(h, explicit, "X-Requested-With", "XMLHttpRequest")
+		}
+	default:
+		setDynamicHeader(h, explicit, "Accept", htmlAccept)
+		setDynamicHeader(h, explicit, "Sec-Fetch-Mode", "navigate")
+		setDynamicHeader(h, explicit, "Sec-Fetch-Dest", "document")
+		if cfg.defaultSecFetchUser {
+			setDynamicHeader(h, explicit, "Sec-Fetch-User", "?1")
+		}
+		setDynamicHeader(h, explicit, "Upgrade-Insecure-Requests", "1")
+	}
+	h.Del(browserRequestKindHeader)
+}
+```
+
+Add `context` and `github.com/imroc/req/v3` to the import list in `httpx/browser_navigation.go`.
+
+- [ ] **Step 2: Install wrapper in factory build**
+
+In `httpx/factory.go`, after registering global/client request interceptors and before request logging, add:
+
+```go
+if o.browserNavigation != nil {
+	installBrowserNavigation(c, o.browserNavigation)
+}
+```
+
+This ordering captures headers after user request interceptors have had a chance to mark explicit headers, and applies dynamic headers later in the round-trip wrapper.
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+go test ./httpx -run BrowserNavigation -count=1
+```
+
+Expected: Task 1 and Task 3 tests pass.
+
+## Task 5: Cover Precedence, Browser Profile, Isolation, Clone, And Redirect
+
+**Files:**
+- Modify: `httpx/browser_navigation_test.go`
+
+- [ ] **Step 1: Add header precedence test**
+
+Append:
+
+```go
+func TestBrowserNavigation_doesNotOverrideSingleRequestExplicitHeaders(t *testing.T) {
+	srv, seen := navigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(srv.URL),
+		httpx.WithBrowserNavigation(),
+		httpx.WithHeader("Sec-Fetch-Site", "profile-default"),
+	)
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().
+		SetHeader("Sec-Fetch-Site", "manual").
+		SetHeader("Referer", "https://manual.example/path").
+		SetHeader("Accept", "text/custom").
+		Get("/manual"); err != nil {
+		t.Fatal(err)
+	}
+
+	got := (*seen)[0]
+	if got.SecFetchSite != "manual" || got.Referer != "https://manual.example/path" || got.Accept != "text/custom" {
+		t.Fatalf("explicit headers should win, got %+v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Add browser profile dynamic override test**
+
+Append:
+
+```go
+func TestBrowserNavigation_overridesBrowserProfileDynamicDefaults(t *testing.T) {
+	srv, seen := navigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(srv.URL),
+		httpx.WithBrowser(httpx.BrowserChrome),
+		httpx.WithBrowserNavigation(),
+	)
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().Get("/first"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Req().Get("/second"); err != nil {
+		t.Fatal(err)
+	}
+
+	if (*seen)[1].SecFetchSite != "same-origin" {
+		t.Fatalf("navigation should override browser profile static Sec-Fetch-Site, got %+v", (*seen)[1])
+	}
+}
+```
+
+- [ ] **Step 3: Add independent-client and clone-state tests**
+
+Append:
+
+```go
+func TestBrowserNavigation_newClientStateIsolation(t *testing.T) {
+	srv, seen := navigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser", httpx.WithBaseURL(srv.URL), httpx.WithBrowserNavigation())
+
+	first := f.MustNewClient("browser")
+	second := f.MustNewClient("browser")
+	if _, err := first.Req().Get("/first"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := second.Req().Get("/second"); err != nil {
+		t.Fatal(err)
+	}
+
+	if (*seen)[1].Referer != "" || (*seen)[1].SecFetchSite != "none" {
+		t.Fatalf("second client should start with empty navigation state, got %+v", (*seen)[1])
+	}
+}
+
+func TestBrowserNavigation_cloneSharesState(t *testing.T) {
+	srv, seen := navigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser", httpx.WithBaseURL(srv.URL), httpx.WithBrowserNavigation())
+	original := f.MustNewClient("browser")
+
+	if _, err := original.Req().Get("/first"); err != nil {
+		t.Fatal(err)
+	}
+	clone := original.Clone()
+	if _, err := clone.Req().Get("/second"); err != nil {
+		t.Fatal(err)
+	}
+
+	wantReferer := srv.URL + "/first"
+	if (*seen)[1].Referer != wantReferer {
+		t.Fatalf("clone should share navigation state, want Referer %q, got %+v", wantReferer, (*seen)[1])
+	}
+}
+```
+
+- [ ] **Step 4: Add redirect final URL test**
+
+Append:
+
+```go
+func TestBrowserNavigation_remembersFinalURLAfterRedirect(t *testing.T) {
+	var seen []seenNavigationHeaders
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/start":
+			http.Redirect(w, r, "/landing", http.StatusFound)
+		default:
+			seen = append(seen, seenNavigationHeaders{
+				Referer:      r.Header.Get("Referer"),
+				SecFetchSite: r.Header.Get("Sec-Fetch-Site"),
+			})
+			_, _ = w.Write([]byte("ok"))
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser", httpx.WithBaseURL(srv.URL), httpx.WithBrowserNavigation())
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().Get("/start"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Req().Get("/next"); err != nil {
+		t.Fatal(err)
+	}
+
+	wantReferer := srv.URL + "/landing"
+	if seen[1].Referer != wantReferer {
+		t.Fatalf("Referer should use final redirect URL, want %q, got %+v", wantReferer, seen[1])
+	}
+}
+```
+
+- [ ] **Step 5: Run focused and package tests**
+
+Run:
+
+```bash
+go test ./httpx -run BrowserNavigation -count=1
+go test ./httpx -count=1
+```
+
+Expected: all `httpx` tests pass.
+
+## Task 6: Update Documentation
+
+**Files:**
+- Modify: `httpx/doc.go`
+- Modify: `httpx/README.md`
+
+- [ ] **Step 1: Update package doc**
+
+In `httpx/doc.go`, replace the feature sentence:
+
+```go
+// limiting (golang.org/x/time/rate), browser impersonation profiles, cookie jars,
+// redirect policies, and opt-in JSON envelope error handling via interceptors.Error.
+```
+
+with:
+
+```go
+// limiting (golang.org/x/time/rate), browser impersonation profiles, browser
+// navigation headers, cookie jars, redirect policies, and opt-in JSON envelope
+// error handling via interceptors.Error.
+```
+
+Append to the ordering paragraph:
+
+```go
+// Browser navigation captures request-explicit headers before req merges common
+// headers, then applies dynamic navigation headers in the client round-trip wrapper
+// after URL and body parsing.
+```
+
+- [ ] **Step 2: Update README API list**
+
+In `httpx/README.md`, add this item under `ClientOption`:
+
+```markdown
+- `WithBrowserNavigation(opts ...BrowserNavigationOption)`
+```
+
+Add a new `BrowserNavigationOption` list near the browser navigation section:
+
+```markdown
+### BrowserNavigationOption
+
+- `WithReferrerPolicy(policy ReferrerPolicy)`
+- `WithXHRForJSON(enabled bool)`
+- `WithDefaultXRequestedWith(enabled bool)`
+- `WithDefaultSecFetchUser(enabled bool)`
+```
+
+Under `Client 方法`, add:
+
+```markdown
+- `(*Request).WithBrowserRequestKind(kind BrowserRequestKind) *Request`
+- `(*Request).AsXHR() *Request`
+- `(*Request).AsNavigation() *Request`
+```
+
+- [ ] **Step 3: Add README browser navigation section**
+
+Add a section after the browser profile section:
+
+```markdown
+## 浏览器导航 header
+
+`WithBrowser(...)` 负责 TLS/HTTP2 指纹、浏览器默认 header 和 header order；`WithBrowserNavigation(...)` 负责单个 caller-owned client 内的动态导航 header：
+
+- 首次请求自动设置 `Sec-Fetch-Site: none`，不设置 `Referer`
+- 同源后续请求用上一跳完整 URL 作为 `Referer`
+- 跨源后续请求按 `strict-origin-when-cross-origin` 收敛为上一跳 origin
+- POST 请求自动补当前请求 `Origin`
+- JSON 请求默认使用 XHR 风格 `Accept` / `Sec-Fetch-Mode` / `Sec-Fetch-Dest`
+- HTML/form 请求默认使用 navigation 风格 header
+- 单次请求显式设置的 header 不会被覆盖
+
+```go
+factory.RegisterProfile("flow-upstream",
+	httpx.WithBrowser(httpx.BrowserChrome),
+	httpx.WithBrowserNavigation(
+		httpx.WithReferrerPolicy(httpx.ReferrerPolicyStrictOriginWhenCrossOrigin),
+		httpx.WithXHRForJSON(true),
+	),
+)
+
+session := factory.MustNewClient("flow-upstream")
+_, _ = session.Req().Get("https://login.example.com/")
+_, _ = session.Req().AsXHR().SetBodyJsonMarshal(map[string]string{"step": "check"}).Post("https://login.example.com/api/check")
+
+noRedirect := session.Clone().SetRedirectPolicy(httpx.NoRedirectPolicy())
+_, _ = noRedirect.Req().Get("https://login.example.com/redirect-once")
+```
+
+`ClientFactory` 不保存导航状态。每次 `NewClient` / `MustNewClient` 都是新的浏览器会话；`Clone()` 用于同一会话内的临时变体，并共享上一跳 URL。
+```
+
+- [ ] **Step 4: Run docs-adjacent tests**
+
+Run:
+
+```bash
+go test ./httpx -count=1
+```
+
+Expected: all `httpx` tests pass.
+
+## Task 7: Final Verification
+
+**Files:**
+- No planned edits beyond previous tasks.
+
+- [ ] **Step 1: Run module tests**
+
+Run:
+
+```bash
+go test ./httpx -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run workspace-level package listing**
+
+Run:
+
+```bash
+go list ./... ./httpx/...
+```
+
+Expected: all packages list successfully.
+
+- [ ] **Step 3: Run GitNexus change detection**
+
+Run MCP:
+
+```text
+detect_changes(repo: "gcommon", scope: "all")
+```
+
+Expected: changes limited to `httpx` browser navigation symbols and docs. Any unexpected affected process must be inspected before commit.
+
+## Spec Coverage Review
+
+- Dynamic `Referer`, `Sec-Fetch-Site`, POST `Origin`: Task 1, Task 3, Task 4.
+- HTML navigation and JSON/XHR defaults: Task 1, Task 3, Task 4.
+- Single-request explicit header priority: Task 4 and Task 5.
+- `WithBrowser(...)` coexistence and dynamic override: Task 5.
+- New-client state isolation: Task 5.
+- Clone shared state: Task 5.
+- Redirect final URL: Task 5.
+- Docs and session semantics: Task 6.
+- GitNexus controls: GitNexus Controls section and Task 7.

--- a/docs/superpowers/specs/2026-05-06-httpx-browser-navigation.md
+++ b/docs/superpowers/specs/2026-05-06-httpx-browser-navigation.md
@@ -1,0 +1,197 @@
+# httpx Browser Navigation Spec
+
+## 背景
+
+`httpx` 现有 `WithBrowser(BrowserChrome)` 已经把 TLS/HTTP2 指纹、浏览器默认 header 和 header order 交给 `github.com/imroc/req/v3` 的浏览器模拟能力处理。`httpx.md` 描述的新增需求不是继续增加业务方手写 header，而是在单个 `httpx.Client` 内维护浏览器式导航状态，让调用方可以用同一个 caller-owned client 表达一段顺序浏览器会话。
+
+该能力的直接下游是 `sso-broker/internal/upstream.Session`，但 `httpx` 只提供通用浏览器导航语义，不包含 ISC SSO、PMS30、ticket、cookie、账号密码、业务错误解析或日志脱敏规则。
+
+## 目标
+
+- 提供 `WithBrowserNavigation(...) ClientOption`，为某个新建 `httpx.Client` 开启浏览器导航 header 维护。
+- 在最终发送请求前，根据当前请求和上一跳最终 URL 补全 `Referer`、`Sec-Fetch-Site`、POST `Origin`、HTML navigation header、JSON/XHR header。
+- 每次 `ClientFactory.NewClient` / `MustNewClient` 创建独立导航状态；`ClientFactory` 只保存 profile，不共享导航状态。
+- `Client.Clone()` 保留导航能力，并共享同一导航状态，支持 no-redirect 临时 clone 继续推进同一会话。
+- 单次请求显式设置的 header 优先级最高；导航层可以覆盖 `WithBrowser(...)` 或 `WithHeader(...)` 注入的 profile 级默认动态 header。
+- redirect 后记录最终响应 URL，下一跳以最终 URL 计算 `Referer` 和 `Sec-Fetch-Site`。
+
+## 非目标
+
+- 不下沉 ISC SSO、PMS30 或其他系统的 URL、步骤顺序、ticket/cookie 语义。
+- 不处理账号、密码、ticket、cookie 等业务敏感字段日志或脱敏策略。
+- 不解释上游响应 body 的业务状态码。
+- 不实现项目专用 WAF 绕过规则。
+- 不把浏览器导航状态放进 `ClientFactory`，也不让 profile 之间共享上一跳 URL。
+
+## Public API
+
+新增 API：
+
+```go
+type BrowserNavigationOption util.Option[browserNavigationConfig]
+
+func WithBrowserNavigation(opts ...BrowserNavigationOption) ClientOption
+
+type ReferrerPolicy string
+
+const (
+	ReferrerPolicyNoReferrer                   ReferrerPolicy = "no-referrer"
+	ReferrerPolicyOrigin                       ReferrerPolicy = "origin"
+	ReferrerPolicyStrictOriginWhenCrossOrigin  ReferrerPolicy = "strict-origin-when-cross-origin"
+)
+
+func WithReferrerPolicy(policy ReferrerPolicy) BrowserNavigationOption
+func WithXHRForJSON(enabled bool) BrowserNavigationOption
+func WithDefaultXRequestedWith(enabled bool) BrowserNavigationOption
+func WithDefaultSecFetchUser(enabled bool) BrowserNavigationOption
+
+type BrowserRequestKind int
+
+const (
+	BrowserRequestAuto BrowserRequestKind = iota
+	BrowserRequestNavigation
+	BrowserRequestXHR
+)
+
+func (r *Request) WithBrowserRequestKind(kind BrowserRequestKind) *Request
+func (r *Request) AsXHR() *Request
+func (r *Request) AsNavigation() *Request
+```
+
+默认配置：
+
+```go
+browserNavigationConfig{
+	referrerPolicy:        ReferrerPolicyStrictOriginWhenCrossOrigin,
+	xhrForJSON:            true,
+	defaultXRequestedWith: false,
+	defaultSecFetchUser:   true,
+}
+```
+
+示例：
+
+```go
+factory.RegisterProfile("flow-upstream",
+	httpx.WithBrowser(httpx.BrowserChrome),
+	httpx.WithBrowserNavigation(
+		httpx.WithReferrerPolicy(httpx.ReferrerPolicyStrictOriginWhenCrossOrigin),
+		httpx.WithXHRForJSON(true),
+	),
+)
+
+client := factory.MustNewClient("flow-upstream")
+_, _ = client.Req().Get("https://example.com/login")
+_, _ = client.Req().AsXHR().SetBodyJsonMarshal(map[string]string{"ok": "1"}).Post("https://example.com/api")
+```
+
+## Header 语义
+
+### 显式 header 识别
+
+导航层必须区分“单次请求显式设置”和“client/profile/common header 注入”：
+
+- 在 `req.Client.OnBeforeRequest` 阶段捕获 `req.Request.Headers` 中已有的 header key。该阶段发生在 req 内部 `parseRequestHeader` 把 client common headers 合并进 request 之前。
+- 捕获 hook 应注册在用户 `WithReqInterceptor` 之后，使用户在请求拦截器中设置的 header 也视为显式 header。
+- 动态导航 header 在 `req.Client.WrapRoundTripFunc` 阶段应用，此时 URL、method、body 和 content type 已经解析完成。
+- 显式 header key 一律不覆盖；非显式 header 可以被导航层覆盖，即使该值来自 `WithBrowser(...)` 或 `WithHeader(...)`。
+
+### Referer
+
+- 首次请求没有上一跳 URL 时，不设置 `Referer`。
+- `ReferrerPolicyNoReferrer` 永不自动设置 `Referer`。
+- `ReferrerPolicyOrigin` 使用上一跳 origin，例如 `https://example.com/`。
+- `ReferrerPolicyStrictOriginWhenCrossOrigin`：
+  - 同源请求使用上一跳完整 URL。
+  - 跨源请求使用上一跳 origin。
+- 单次请求显式 `Referer` 不覆盖。
+
+### Sec-Fetch-Site
+
+- 首次请求没有上一跳 URL 时设置 `none`。
+- 当前 URL 与上一跳 URL 同 scheme 且同 host 时设置 `same-origin`。
+- 其他情况设置 `cross-site`。
+- 单次请求显式 `Sec-Fetch-Site` 不覆盖。
+
+### Origin
+
+- POST 请求没有显式 `Origin` 时，按当前请求 URL 生成 origin。
+- 非 POST 请求默认不补 `Origin`。
+
+### HTML Navigation
+
+当请求类型为 navigation 时，默认补：
+
+```text
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
+Sec-Fetch-Mode: navigate
+Sec-Fetch-Dest: document
+Sec-Fetch-User: ?1
+Upgrade-Insecure-Requests: 1
+```
+
+`Sec-Fetch-User` 受 `WithDefaultSecFetchUser(false)` 控制。单次请求显式 header 不覆盖。
+
+### JSON/XHR
+
+请求类型判定：
+
+- `Request.AsXHR()` 或 `WithBrowserRequestKind(BrowserRequestXHR)` 显式标记为 XHR。
+- `WithXHRForJSON(true)` 且 `Content-Type` 以 `application/json` 开头时，自动判定为 XHR。
+- `Request.AsNavigation()` 显式标记为 navigation，即使 content type 是 JSON 也按 navigation 处理。
+
+XHR 默认补：
+
+```text
+Accept: application/json, text/plain, */*
+Sec-Fetch-Mode: cors
+Sec-Fetch-Dest: empty
+```
+
+`X-Requested-With: XMLHttpRequest` 仅在 `WithDefaultXRequestedWith(true)` 时默认补。单次请求显式 header 不覆盖。
+
+## 状态模型
+
+- `browserNavigationState` 至少包含 `lastURL *url.URL` 和 `sync.Mutex`。
+- 状态属于单个 `ClientFactory.NewClient` / `MustNewClient` 创建出的 `httpx.Client`。
+- `Client.Clone()` 通过 req clone 复制 wrapper 闭包，闭包捕获同一个 state 指针，因此 clone 共享上一跳 URL。
+- 状态更新以响应最终 URL 为准：优先使用 `resp.Request.URL`，没有响应时不推进状态。
+- 该 client 语义上对应一个顺序浏览器会话。实现需要基本并发保护，但文档应声明不建议跨用户、跨登录会话并发复用同一 browser navigation client。
+
+## 实现边界
+
+- `WithBrowserNavigation` 写入 `clientRegisterOpts.browserNavigation *browserNavigationConfig`。
+- `BrowserNavigationOption` 沿用现有 `ClientOption` / `FactoryOption` 的 `util.Option` 风格。
+- `clientRegisterOpts.clone()` 深拷贝配置值，但不拷贝运行时状态。
+- `ClientFactory.buildReqClient` 在每次创建 client 时按配置创建新的 `browserNavigationState` 并安装导航 wrapper。
+- `Request.WithBrowserRequestKind` 使用内部 sentinel header 在 req 请求对象上传递单次请求类型；导航 wrapper 发送前删除该 sentinel header。
+- `WithBrowser(...)` 继续负责浏览器指纹、header order 和静态默认 header；导航层只负责动态导航字段。
+
+## GitNexus 影响面基线
+
+本 spec 制定前已按 AGENTS 要求对计划会涉及的核心符号运行上游影响分析：
+
+| Symbol | Risk | Direct callers | Affected processes |
+| --- | --- | --- | --- |
+| `Client` (`httpx/client.go`) | LOW | `Client.Clone` | 无 |
+| `Client.Clone` (`httpx/client.go`) | LOW | 无 | 无 |
+| `ClientFactory.buildReqClient` (`httpx/factory.go`) | LOW | `ClientFactory.NewClient` | `MustNewClient`, low-confidence `cloud/module/consul/client.go:New` |
+| `clientRegisterOpts` (`httpx/client_options.go`) | LOW | `newClientRegisterOpts` | `RegisterProfile` |
+| `applyBrowserProfile` (`httpx/browser.go`) | LOW | `ClientFactory.buildReqClient` | `MustNewClient`, low-confidence `cloud/module/consul/client.go:New` |
+
+没有 HIGH 或 CRITICAL 风险。后续真正编辑这些符号前仍需重新运行对应 impact，提交前必须运行 `gitnexus_detect_changes()` / MCP `detect_changes`。
+
+## 测试要求
+
+- 首次请求：`Sec-Fetch-Site=none`，无 `Referer`。
+- 同源第二次请求：`Sec-Fetch-Site=same-origin`，`Referer` 为上一跳完整 URL。
+- 跨源请求：`Sec-Fetch-Site=cross-site`，`Referer` 按策略收敛为 origin。
+- POST 请求自动补当前请求 origin。
+- JSON 请求自动补 XHR 风格 header。
+- HTML/form 请求自动补 navigation 风格 header。
+- `Request.AsXHR()` 可强制 XHR；`Request.AsNavigation()` 可强制 navigation。
+- 单次请求显式 header 不被覆盖。
+- 与 `WithBrowser(BrowserChrome)` 同时启用时，动态字段能覆盖 browser profile 的静态 `Sec-Fetch-Site`。
+- `NewClient` 之间状态隔离。
+- `Clone` 后 no-redirect 请求共享导航状态。
+- redirect 后记录最终 URL。

--- a/go.work.sum
+++ b/go.work.sum
@@ -36,6 +36,7 @@ github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aev
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
@@ -151,8 +152,10 @@ github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5t
 go.mongodb.org/mongo-driver v1.14.0 h1:P98w8egYRjYe3XDjxhYJagTokP/H6HzlsnojRgZRd80=
 go.mongodb.org/mongo-driver v1.14.0/go.mod h1:Vzb0Mk/pa7e6cWw85R4F/endUC3u0U9jGcNU603k65c=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
+go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel/metric v1.24.0/go.mod h1:VYhLe1rFfxuTXLgj4CBiyz+9WYBA8pNGJgDcSFRKBco=
+go.opentelemetry.io/otel/metric v1.35.0/go.mod h1:nKVFgxBZ2fReX6IlyW28MgZojkoAkJGaE8CpgeAU3oE=
 go.opentelemetry.io/otel/metric v1.43.0/go.mod h1:RDnPtIxvqlgO8GRW18W6Z/4P462ldprJtfxHxyKd2PY=
 go.uber.org/mock v0.5.2/go.mod h1:wLlUxC2vVTPTaE3UD51E0BGOAElKrILxhVSDYQLld5o=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=

--- a/httpx/README.md
+++ b/httpx/README.md
@@ -123,6 +123,7 @@ _ = c
 - `WithHeader(key, val string)` / `WithHeaders(map[string]string)`
 - `WithUserAgent(ua string)`
 - `WithBrowser(p BrowserProfile)`
+- `WithBrowserNavigation(opts ...BrowserNavigationOption)`
 - `WithLimiter(l *rate.Limiter)` / `DisableLimiter()`
 - `WithRetry(p RetryPolicy)` / `DisableRetry()`
 - `WithReqInterceptor(i ReqInterceptor)` / `WithRespInterceptor(i RespInterceptor)`
@@ -131,6 +132,13 @@ _ = c
 - `WithCookieJar(jar http.CookieJar)` / `WithCookieJarFactory(factory CookieJarFactory)`
 - `WithRedirectPolicy(policies ...RedirectPolicy)`
 - `WithLogger(l *slog.Logger)`（传 `nil` 可禁用该 client 日志）
+
+### BrowserNavigationOption
+
+- `WithReferrerPolicy(policy ReferrerPolicy)`
+- `WithXHRForJSON(enabled bool)`
+- `WithDefaultXRequestedWith(enabled bool)`
+- `WithDefaultSecFetchUser(enabled bool)`
 
 ### Client 方法
 
@@ -141,6 +149,9 @@ _ = c
 - `(*Client).SetCookieJarFactory(factory CookieJarFactory) *Client`
 - `(*Client).GetCookies(rawURL string) ([]*http.Cookie, error)`
 - `(*Client).SetRedirectPolicy(policies ...RedirectPolicy) *Client`
+- `(*Request).WithBrowserRequestKind(kind BrowserRequestKind) *Request`
+- `(*Request).AsXHR() *Request`
+- `(*Request).AsNavigation() *Request`
 
 ### Cookie 和 Redirect
 
@@ -245,6 +256,39 @@ _ = c
 ```
 
 当同时设置 `WithBrowser(...)` 与 `WithUserAgent(...)` 时，优先使用 `BrowserProfile`。
+
+## 浏览器导航 header
+
+`WithBrowser(...)` 负责 TLS/HTTP2 指纹、静态浏览器 header 和 header order；`WithBrowserNavigation(...)` 负责同一个 client 内动态变化的浏览器导航 header，例如 `Referer`、`Origin`、`Sec-Fetch-*` 和按请求类型调整的 `Accept`。
+
+默认行为：
+
+- 首次请求发送 `Sec-Fetch-Site: none`，不发送 `Referer`。
+- 同源后续请求使用上一次完整 URL 作为 `Referer`。
+- 跨源后续请求在默认 `strict-origin-when-cross-origin` 策略下使用上一次 origin 作为 `Referer`。
+- `POST` 请求会追加当前 URL 的 `Origin`。
+- JSON 请求默认按 XHR 设置 `Accept`、`Sec-Fetch-Mode`、`Sec-Fetch-Dest`。
+- HTML/form 请求默认按页面导航设置 header。
+- 单次请求显式设置的 header 不会被动态导航 header 覆盖。
+- `NewClient` / `MustNewClient` 会创建新的浏览器导航状态；`Clone()` 用于同一会话内的临时变体，并共享导航状态。
+- 启用浏览器导航的原始 client 及其 clones 共享同一组导航状态，语义上是一个顺序浏览器会话。不要跨用户、跨登录会话复用；依赖“上一页”语义时，也不要并发使用这一组实例发请求。
+
+```go
+factory.RegisterProfile("flow-upstream",
+	httpx.WithBrowser(httpx.BrowserChrome),
+	httpx.WithBrowserNavigation(
+		httpx.WithReferrerPolicy(httpx.ReferrerPolicyStrictOriginWhenCrossOrigin),
+		httpx.WithXHRForJSON(true),
+	),
+)
+
+session := factory.MustNewClient("flow-upstream")
+_, _ = session.Req().Get("https://login.example.com/")
+_, _ = session.Req().AsXHR().SetBodyJsonMarshal(map[string]string{"step": "check"}).Post("https://login.example.com/api/check")
+
+noRedirect := session.Clone().SetRedirectPolicy(httpx.NoRedirectPolicy())
+_, _ = noRedirect.Req().Get("https://login.example.com/redirect-once")
+```
 
 ## 浏览器式会话
 

--- a/httpx/browser_navigation.go
+++ b/httpx/browser_navigation.go
@@ -1,0 +1,421 @@
+package httpx
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/c1emon/gcommon/v2/util"
+	"github.com/imroc/req/v3"
+)
+
+type BrowserNavigationOption util.Option[browserNavigationConfig]
+
+type ReferrerPolicy string
+
+const (
+	ReferrerPolicyNoReferrer                  ReferrerPolicy = "no-referrer"
+	ReferrerPolicyOrigin                      ReferrerPolicy = "origin"
+	ReferrerPolicyStrictOriginWhenCrossOrigin ReferrerPolicy = "strict-origin-when-cross-origin"
+)
+
+type BrowserRequestKind int
+
+const (
+	BrowserRequestAuto BrowserRequestKind = iota
+	BrowserRequestNavigation
+	BrowserRequestXHR
+)
+
+const (
+	browserRequestKindHeader = "X-Httpx-Browser-Request-Kind"
+	htmlAccept               = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
+	jsonAccept               = "application/json, text/plain, */*"
+)
+
+type explicitHeadersKey struct{}
+
+type browserRequestKindKey struct{}
+
+type browserPreviousURLKey struct{}
+
+type browserNavigationConfig struct {
+	referrerPolicy        ReferrerPolicy
+	xhrForJSON            bool
+	defaultXRequestedWith bool
+	defaultSecFetchUser   bool
+}
+
+type browserNavigationState struct {
+	mu      sync.Mutex
+	lastURL *url.URL
+}
+
+func installBrowserNavigation(c *req.Client, cfg *browserNavigationConfig) {
+	if c == nil || cfg == nil {
+		return
+	}
+
+	state := &browserNavigationState{}
+	c.OnBeforeRequest(func(_ *req.Client, r *req.Request) error {
+		ctx := r.Context()
+		if explicitHeadersFromContext(ctx) != nil {
+			return nil
+		}
+		ctx = contextWithExplicitHeaders(ctx, explicitHeaderKeys(r.Headers))
+		ctx = contextWithBrowserRequestKind(ctx, browserRequestKindFromHeader(r.Headers))
+		r.SetContext(ctx)
+		return nil
+	})
+	c.WrapRoundTripFunc(func(rt req.RoundTripper) req.RoundTripFunc {
+		return func(r *req.Request) (*req.Response, error) {
+			r.SetContext(contextWithPreviousBrowserURL(r.Context(), state.previous()))
+			state.apply(cfg, r, explicitHeadersFromContext(r.Context()), browserRequestKindFromContext(r.Context()))
+			resp, err := rt.RoundTrip(r)
+			if resp != nil && resp.Response != nil && resp.Response.Request != nil {
+				state.remember(resp.Response.Request.URL)
+			}
+			return resp, err
+		}
+	})
+	c.AddCommonRetryHook(func(resp *req.Response, _ error) {
+		if resp == nil || resp.Request == nil {
+			return
+		}
+		prev, ok := previousBrowserURLFromContext(resp.Request.Context())
+		if !ok {
+			return
+		}
+		state.remember(prev)
+	})
+}
+
+func contextWithExplicitHeaders(ctx context.Context, explicit map[string]struct{}) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, explicitHeadersKey{}, explicit)
+}
+
+func contextWithBrowserRequestKind(ctx context.Context, kind BrowserRequestKind) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, browserRequestKindKey{}, kind)
+}
+
+func contextWithPreviousBrowserURL(ctx context.Context, u *url.URL) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, browserPreviousURLKey{}, cloneURL(u))
+}
+
+func explicitHeadersFromContext(ctx context.Context) map[string]struct{} {
+	if ctx == nil {
+		return nil
+	}
+	explicit, _ := ctx.Value(explicitHeadersKey{}).(map[string]struct{})
+	return explicit
+}
+
+func browserRequestKindFromContext(ctx context.Context) BrowserRequestKind {
+	if ctx == nil {
+		return BrowserRequestAuto
+	}
+	kind, _ := ctx.Value(browserRequestKindKey{}).(BrowserRequestKind)
+	return kind
+}
+
+func previousBrowserURLFromContext(ctx context.Context) (*url.URL, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	u, ok := ctx.Value(browserPreviousURLKey{}).(*url.URL)
+	return cloneURL(u), ok
+}
+
+func (s *browserNavigationState) remember(u *url.URL) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastURL = cloneURL(u)
+}
+
+func (s *browserNavigationState) previous() *url.URL {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return cloneURL(s.lastURL)
+}
+
+func (s *browserNavigationState) apply(cfg *browserNavigationConfig, r *req.Request, explicit map[string]struct{}, kind BrowserRequestKind) {
+	if s == nil || cfg == nil || r == nil || r.URL == nil {
+		return
+	}
+	defer deleteInternalBrowserRequestKindHeader(r.Headers)
+	if r.Headers == nil {
+		r.Headers = make(http.Header)
+	}
+
+	current := r.URL
+	prev := s.previous()
+	setOrDeleteDynamicHeader(r.Headers, explicit, "Referer", cfg.refererFor(prev, current))
+	setDynamicHeader(r.Headers, explicit, "Sec-Fetch-Site", secFetchSite(prev, current))
+	if strings.EqualFold(r.Method, http.MethodPost) {
+		setDynamicHeader(r.Headers, explicit, "Origin", originString(current))
+	} else {
+		deleteDynamicHeader(r.Headers, explicit, "Origin")
+	}
+
+	if kind == BrowserRequestAuto {
+		kind = cfg.effectiveRequestKind(r.Headers)
+	}
+	switch kind {
+	case BrowserRequestXHR:
+		setDynamicHeader(r.Headers, explicit, "Accept", jsonAccept)
+		setDynamicHeader(r.Headers, explicit, "Sec-Fetch-Mode", "cors")
+		setDynamicHeader(r.Headers, explicit, "Sec-Fetch-Dest", "empty")
+		if cfg.defaultXRequestedWith {
+			setDynamicHeader(r.Headers, explicit, "X-Requested-With", "XMLHttpRequest")
+		}
+		deleteDynamicHeader(r.Headers, explicit, "Sec-Fetch-User")
+		deleteDynamicHeader(r.Headers, explicit, "Upgrade-Insecure-Requests")
+	case BrowserRequestNavigation:
+		setDynamicHeader(r.Headers, explicit, "Accept", htmlAccept)
+		setDynamicHeader(r.Headers, explicit, "Sec-Fetch-Mode", "navigate")
+		setDynamicHeader(r.Headers, explicit, "Sec-Fetch-Dest", "document")
+		if cfg.defaultSecFetchUser {
+			setDynamicHeader(r.Headers, explicit, "Sec-Fetch-User", "?1")
+		}
+		setDynamicHeader(r.Headers, explicit, "Upgrade-Insecure-Requests", "1")
+		deleteDynamicHeader(r.Headers, explicit, "X-Requested-With")
+	}
+}
+
+func defaultBrowserNavigationConfig() *browserNavigationConfig {
+	return &browserNavigationConfig{
+		referrerPolicy:        ReferrerPolicyStrictOriginWhenCrossOrigin,
+		xhrForJSON:            true,
+		defaultXRequestedWith: false,
+		defaultSecFetchUser:   true,
+	}
+}
+
+func (c *browserNavigationConfig) clone() *browserNavigationConfig {
+	if c == nil {
+		return nil
+	}
+	out := *c
+	return &out
+}
+
+func WithBrowserNavigation(opts ...BrowserNavigationOption) ClientOption {
+	return util.WrapFuncOption(func(o *clientRegisterOpts) {
+		cfg := defaultBrowserNavigationConfig()
+		for _, opt := range opts {
+			opt.Apply(cfg)
+		}
+		o.browserNavigation = cfg
+	})
+}
+
+func WithReferrerPolicy(policy ReferrerPolicy) BrowserNavigationOption {
+	return util.WrapFuncOption(func(c *browserNavigationConfig) {
+		c.referrerPolicy = policy
+	})
+}
+
+func WithXHRForJSON(enabled bool) BrowserNavigationOption {
+	return util.WrapFuncOption(func(c *browserNavigationConfig) {
+		c.xhrForJSON = enabled
+	})
+}
+
+func WithDefaultXRequestedWith(enabled bool) BrowserNavigationOption {
+	return util.WrapFuncOption(func(c *browserNavigationConfig) {
+		c.defaultXRequestedWith = enabled
+	})
+}
+
+func WithDefaultSecFetchUser(enabled bool) BrowserNavigationOption {
+	return util.WrapFuncOption(func(c *browserNavigationConfig) {
+		c.defaultSecFetchUser = enabled
+	})
+}
+
+func (r *Request) WithBrowserRequestKind(kind BrowserRequestKind) *Request {
+	if r == nil || r.Request == nil {
+		return r
+	}
+
+	switch kind {
+	case BrowserRequestNavigation:
+		r.SetHeader(browserRequestKindHeader, "navigation")
+	case BrowserRequestXHR:
+		r.SetHeader(browserRequestKindHeader, "xhr")
+	default:
+		delete(r.Request.Headers, browserRequestKindHeader)
+	}
+	return r
+}
+
+func (r *Request) AsXHR() *Request {
+	return r.WithBrowserRequestKind(BrowserRequestXHR)
+}
+
+func (r *Request) AsNavigation() *Request {
+	return r.WithBrowserRequestKind(BrowserRequestNavigation)
+}
+
+func sameOrigin(a, b *url.URL) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return strings.EqualFold(a.Scheme, b.Scheme) && strings.EqualFold(a.Host, b.Host)
+}
+
+func originString(u *url.URL) string {
+	if u == nil || u.Scheme == "" || u.Host == "" {
+		return ""
+	}
+	return u.Scheme + "://" + u.Host
+}
+
+func originReferer(u *url.URL) string {
+	origin := originString(u)
+	if origin == "" {
+		return ""
+	}
+	return origin + "/"
+}
+
+func cloneURL(u *url.URL) *url.URL {
+	if u == nil {
+		return nil
+	}
+	out := *u
+	return &out
+}
+
+func explicitHeaderKeys(h http.Header) map[string]struct{} {
+	explicit := make(map[string]struct{}, len(h))
+	for key := range h {
+		canonicalKey := http.CanonicalHeaderKey(key)
+		if canonicalKey == browserRequestKindHeader {
+			continue
+		}
+		explicit[canonicalKey] = struct{}{}
+	}
+	return explicit
+}
+
+func hasExplicitHeader(explicit map[string]struct{}, key string) bool {
+	if explicit == nil {
+		return false
+	}
+	_, ok := explicit[http.CanonicalHeaderKey(key)]
+	return ok
+}
+
+func setDynamicHeader(h http.Header, explicit map[string]struct{}, key, value string) {
+	if value == "" || hasExplicitHeader(explicit, key) {
+		return
+	}
+	h.Set(key, value)
+}
+
+func setOrDeleteDynamicHeader(h http.Header, explicit map[string]struct{}, key, value string) {
+	if value == "" {
+		deleteDynamicHeader(h, explicit, key)
+		return
+	}
+	setDynamicHeader(h, explicit, key, value)
+}
+
+func deleteDynamicHeader(h http.Header, explicit map[string]struct{}, key string) {
+	if h == nil || hasExplicitHeader(explicit, key) {
+		return
+	}
+	h.Del(key)
+}
+
+func deleteInternalBrowserRequestKindHeader(h http.Header) {
+	for key := range h {
+		if strings.EqualFold(key, browserRequestKindHeader) {
+			delete(h, key)
+		}
+	}
+}
+
+func browserRequestKindFromHeader(h http.Header) BrowserRequestKind {
+	if kind := parseBrowserRequestKindValues(h[browserRequestKindHeader]); kind != BrowserRequestAuto {
+		return kind
+	}
+	for key, values := range h {
+		if key == browserRequestKindHeader || !strings.EqualFold(key, browserRequestKindHeader) {
+			continue
+		}
+		if kind := parseBrowserRequestKindValues(values); kind != BrowserRequestAuto {
+			return kind
+		}
+	}
+	return BrowserRequestAuto
+}
+
+func parseBrowserRequestKindValues(values []string) BrowserRequestKind {
+	for _, value := range values {
+		switch strings.ToLower(strings.TrimSpace(value)) {
+		case "navigation":
+			return BrowserRequestNavigation
+		case "xhr":
+			return BrowserRequestXHR
+		}
+	}
+	return BrowserRequestAuto
+}
+
+func isJSONContentType(ct string) bool {
+	ct = strings.ToLower(strings.TrimSpace(ct))
+	return ct == "application/json" || strings.HasPrefix(ct, "application/json;")
+}
+
+func (c *browserNavigationConfig) effectiveRequestKind(h http.Header) BrowserRequestKind {
+	kind := browserRequestKindFromHeader(h)
+	if kind != BrowserRequestAuto {
+		return kind
+	}
+	if c != nil && c.xhrForJSON && isJSONContentType(h.Get("Content-Type")) {
+		return BrowserRequestXHR
+	}
+	return BrowserRequestNavigation
+}
+
+func (c *browserNavigationConfig) refererFor(prev, current *url.URL) string {
+	if prev == nil || c == nil || c.referrerPolicy == ReferrerPolicyNoReferrer {
+		return ""
+	}
+	if c.referrerPolicy == ReferrerPolicyOrigin {
+		return originReferer(prev)
+	}
+	if sameOrigin(prev, current) {
+		return prev.String()
+	}
+	return originReferer(prev)
+}
+
+func secFetchSite(prev, current *url.URL) string {
+	if prev == nil {
+		return "none"
+	}
+	if sameOrigin(prev, current) {
+		return "same-origin"
+	}
+	return "cross-site"
+}

--- a/httpx/browser_navigation_test.go
+++ b/httpx/browser_navigation_test.go
@@ -1,0 +1,561 @@
+package httpx_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/c1emon/gcommon/httpx/v2"
+)
+
+type seenNavigationHeaders struct {
+	Accept                  string `json:"accept"`
+	Referer                 string `json:"referer"`
+	Origin                  string `json:"origin"`
+	SecFetchSite            string `json:"secFetchSite"`
+	SecFetchMode            string `json:"secFetchMode"`
+	SecFetchDest            string `json:"secFetchDest"`
+	SecFetchUser            string `json:"secFetchUser"`
+	UpgradeInsecureRequests string `json:"upgradeInsecureRequests"`
+	XRequestedWith          string `json:"xRequestedWith"`
+	InternalRequestKind     string `json:"internalRequestKind"`
+}
+
+type navigationRecorder struct {
+	server *httptest.Server
+	seen   []seenNavigationHeaders
+}
+
+func newNavigationRecorder(t *testing.T) *navigationRecorder {
+	t.Helper()
+
+	rec := &navigationRecorder{}
+	rec.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := seenNavigationHeaders{
+			Accept:                  r.Header.Get("Accept"),
+			Referer:                 r.Header.Get("Referer"),
+			Origin:                  r.Header.Get("Origin"),
+			SecFetchSite:            r.Header.Get("Sec-Fetch-Site"),
+			SecFetchMode:            r.Header.Get("Sec-Fetch-Mode"),
+			SecFetchDest:            r.Header.Get("Sec-Fetch-Dest"),
+			SecFetchUser:            r.Header.Get("Sec-Fetch-User"),
+			UpgradeInsecureRequests: r.Header.Get("Upgrade-Insecure-Requests"),
+			XRequestedWith:          r.Header.Get("X-Requested-With"),
+			InternalRequestKind:     r.Header.Get("X-Httpx-Browser-Request-Kind"),
+		}
+		rec.seen = append(rec.seen, h)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(rec.server.Close)
+	return rec
+}
+
+func TestBrowserNavigation_firstNavigationHeaders(t *testing.T) {
+	rec := newNavigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(rec.server.URL),
+		httpx.WithBrowserNavigation(),
+	)
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().Get("/login?next=%2Fhome"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rec.seen) != 1 {
+		t.Fatalf("requests seen: want 1, got %d", len(rec.seen))
+	}
+	first := rec.seen[0]
+	if first.SecFetchSite != "none" {
+		t.Fatalf("Sec-Fetch-Site: want none, got %q", first.SecFetchSite)
+	}
+	if first.Referer != "" {
+		t.Fatalf("Referer: want empty, got %q", first.Referer)
+	}
+	if !strings.Contains(first.Accept, "text/html") || !strings.Contains(first.Accept, "application/xhtml+xml") {
+		t.Fatalf("Accept: want HTML navigation values, got %q", first.Accept)
+	}
+	if first.SecFetchMode != "navigate" {
+		t.Fatalf("Sec-Fetch-Mode: want navigate, got %q", first.SecFetchMode)
+	}
+	if first.SecFetchDest != "document" {
+		t.Fatalf("Sec-Fetch-Dest: want document, got %q", first.SecFetchDest)
+	}
+	if first.SecFetchUser != "?1" {
+		t.Fatalf("Sec-Fetch-User: want ?1, got %q", first.SecFetchUser)
+	}
+	if first.UpgradeInsecureRequests != "1" {
+		t.Fatalf("Upgrade-Insecure-Requests: want 1, got %q", first.UpgradeInsecureRequests)
+	}
+	if first.XRequestedWith != "" {
+		t.Fatalf("X-Requested-With: want empty for navigation, got %q", first.XRequestedWith)
+	}
+}
+
+func TestBrowserNavigation_sameOriginSecondRequestUsesPreviousFullURL(t *testing.T) {
+	rec := newNavigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(rec.server.URL),
+		httpx.WithBrowserNavigation(),
+	)
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().Get("/login?next=%2Fhome"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Req().Get("/home"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rec.seen) != 2 {
+		t.Fatalf("requests seen: want 2, got %d", len(rec.seen))
+	}
+	second := rec.seen[1]
+	if second.SecFetchSite != "same-origin" {
+		t.Fatalf("Sec-Fetch-Site: want same-origin, got %q", second.SecFetchSite)
+	}
+	wantReferer := rec.server.URL + "/login?next=%2Fhome"
+	if second.Referer != wantReferer {
+		t.Fatalf("Referer: want %q, got %q", wantReferer, second.Referer)
+	}
+}
+
+func TestBrowserNavigation_crossOriginRefererUsesPreviousOrigin(t *testing.T) {
+	first := newNavigationRecorder(t)
+	second := newNavigationRecorder(t)
+
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser", httpx.WithBrowserNavigation())
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().Get(first.server.URL + "/start?ticket=abc"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Req().Get(second.server.URL + "/next"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(second.seen) != 1 {
+		t.Fatalf("cross-origin requests seen: want 1, got %d", len(second.seen))
+	}
+	got := second.seen[0]
+	if got.SecFetchSite != "cross-site" {
+		t.Fatalf("Sec-Fetch-Site: want cross-site, got %q", got.SecFetchSite)
+	}
+	wantReferer := first.server.URL + "/"
+	if got.Referer != wantReferer {
+		t.Fatalf("Referer: want %q, got %q", wantReferer, got.Referer)
+	}
+}
+
+func TestBrowserNavigation_postAddsCurrentOrigin(t *testing.T) {
+	rec := newNavigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(rec.server.URL),
+		httpx.WithBrowserNavigation(),
+	)
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().Post("/submit"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rec.seen) != 1 {
+		t.Fatalf("requests seen: want 1, got %d", len(rec.seen))
+	}
+	if rec.seen[0].Origin != rec.server.URL {
+		t.Fatalf("Origin: want %q, got %q", rec.server.URL, rec.seen[0].Origin)
+	}
+}
+
+func TestBrowserNavigation_jsonRequestDefaultsToXHR(t *testing.T) {
+	rec := newNavigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(rec.server.URL),
+		httpx.WithBrowserNavigation(),
+	)
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().SetBodyJsonMarshal(map[string]string{"hello": "world"}).Post("/api"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rec.seen) != 1 {
+		t.Fatalf("requests seen: want 1, got %d", len(rec.seen))
+	}
+	got := rec.seen[0]
+	if got.Accept != "application/json, text/plain, */*" {
+		t.Fatalf("Accept: want JSON XHR value, got %q", got.Accept)
+	}
+	if got.SecFetchMode != "cors" {
+		t.Fatalf("Sec-Fetch-Mode: want cors, got %q", got.SecFetchMode)
+	}
+	if got.SecFetchDest != "empty" {
+		t.Fatalf("Sec-Fetch-Dest: want empty, got %q", got.SecFetchDest)
+	}
+	if got.SecFetchUser != "" {
+		t.Fatalf("Sec-Fetch-User: want empty for XHR, got %q", got.SecFetchUser)
+	}
+	if got.UpgradeInsecureRequests != "" {
+		t.Fatalf("Upgrade-Insecure-Requests: want empty for XHR, got %q", got.UpgradeInsecureRequests)
+	}
+}
+
+func TestBrowserNavigation_asNavigationOverridesJSONRequestKind(t *testing.T) {
+	rec := newNavigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(rec.server.URL),
+		httpx.WithBrowserNavigation(),
+	)
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().AsNavigation().SetBodyJsonMarshal(map[string]string{"hello": "world"}).Post("/form"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rec.seen) != 1 {
+		t.Fatalf("requests seen: want 1, got %d", len(rec.seen))
+	}
+	got := rec.seen[0]
+	if got.SecFetchMode != "navigate" {
+		t.Fatalf("Sec-Fetch-Mode: want navigate, got %q", got.SecFetchMode)
+	}
+	if got.SecFetchDest != "document" {
+		t.Fatalf("Sec-Fetch-Dest: want document, got %q", got.SecFetchDest)
+	}
+}
+
+func TestBrowserNavigation_doesNotOverrideSingleRequestExplicitHeaders(t *testing.T) {
+	rec := newNavigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(rec.server.URL),
+		httpx.WithHeader("Sec-Fetch-Site", "profile-default"),
+		httpx.WithBrowserNavigation(),
+	)
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().
+		SetHeader("Sec-Fetch-Site", "manual").
+		SetHeader("Referer", "https://manual.example/path").
+		SetHeader("Accept", "text/custom").
+		Get("/manual"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rec.seen) != 1 {
+		t.Fatalf("requests seen: want 1, got %d", len(rec.seen))
+	}
+	got := rec.seen[0]
+	if got.SecFetchSite != "manual" {
+		t.Fatalf("Sec-Fetch-Site: want manual, got %q", got.SecFetchSite)
+	}
+	if got.Referer != "https://manual.example/path" {
+		t.Fatalf("Referer: want explicit value, got %q", got.Referer)
+	}
+	if got.Accept != "text/custom" {
+		t.Fatalf("Accept: want explicit value, got %q", got.Accept)
+	}
+}
+
+func TestBrowserNavigation_removesProfileDynamicHeadersWhenNavigationOmitsThem(t *testing.T) {
+	rec := newNavigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(rec.server.URL),
+		httpx.WithHeader("Referer", "https://profile.example/previous"),
+		httpx.WithHeader("Origin", "https://profile.example"),
+		httpx.WithBrowserNavigation(),
+	)
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().Get("/first"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rec.seen) != 1 {
+		t.Fatalf("requests seen: want 1, got %d", len(rec.seen))
+	}
+	got := rec.seen[0]
+	if got.Referer != "" {
+		t.Fatalf("Referer: want empty on first navigation, got %q", got.Referer)
+	}
+	if got.Origin != "" {
+		t.Fatalf("Origin: want empty for GET, got %q", got.Origin)
+	}
+}
+
+func TestBrowserNavigation_noReferrerPolicyRemovesProfileReferer(t *testing.T) {
+	rec := newNavigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(rec.server.URL),
+		httpx.WithHeader("Referer", "https://profile.example/previous"),
+		httpx.WithBrowserNavigation(
+			httpx.WithReferrerPolicy(httpx.ReferrerPolicyNoReferrer),
+		),
+	)
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().Get("/first"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Req().Get("/second"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rec.seen) != 2 {
+		t.Fatalf("requests seen: want 2, got %d", len(rec.seen))
+	}
+	for i, got := range rec.seen {
+		if got.Referer != "" {
+			t.Fatalf("request %d Referer: want empty, got %q", i+1, got.Referer)
+		}
+	}
+}
+
+func TestBrowserNavigation_overridesBrowserProfileSecFetchSite(t *testing.T) {
+	rec := newNavigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(rec.server.URL),
+		httpx.WithBrowser(httpx.BrowserChrome),
+		httpx.WithBrowserNavigation(),
+	)
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().Get("/first"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Req().Get("/second"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rec.seen) != 2 {
+		t.Fatalf("requests seen: want 2, got %d", len(rec.seen))
+	}
+	if rec.seen[1].SecFetchSite != "same-origin" {
+		t.Fatalf("Sec-Fetch-Site: want same-origin, got %q", rec.seen[1].SecFetchSite)
+	}
+}
+
+func TestBrowserNavigation_newClientStateIsolation(t *testing.T) {
+	rec := newNavigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(rec.server.URL),
+		httpx.WithBrowserNavigation(),
+	)
+
+	first := f.MustNewClient("browser")
+	second := f.MustNewClient("browser")
+	if _, err := first.Req().Get("/first"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := second.Req().Get("/second"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rec.seen) != 2 {
+		t.Fatalf("requests seen: want 2, got %d", len(rec.seen))
+	}
+	got := rec.seen[1]
+	if got.Referer != "" {
+		t.Fatalf("second client Referer: want empty, got %q", got.Referer)
+	}
+	if got.SecFetchSite != "none" {
+		t.Fatalf("second client Sec-Fetch-Site: want none, got %q", got.SecFetchSite)
+	}
+}
+
+func TestBrowserNavigation_cloneSharesState(t *testing.T) {
+	rec := newNavigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(rec.server.URL),
+		httpx.WithBrowserNavigation(),
+	)
+	original := f.MustNewClient("browser")
+
+	if _, err := original.Req().Get("/first"); err != nil {
+		t.Fatal(err)
+	}
+	clone := original.Clone()
+	if _, err := clone.Req().Get("/second"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := original.Req().Get("/third"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rec.seen) != 3 {
+		t.Fatalf("requests seen: want 3, got %d", len(rec.seen))
+	}
+	wantCloneReferer := rec.server.URL + "/first"
+	if rec.seen[1].Referer != wantCloneReferer {
+		t.Fatalf("clone Referer: want %q, got %q", wantCloneReferer, rec.seen[1].Referer)
+	}
+	wantOriginalReferer := rec.server.URL + "/second"
+	if rec.seen[2].Referer != wantOriginalReferer {
+		t.Fatalf("original Referer after clone request: want %q, got %q", wantOriginalReferer, rec.seen[2].Referer)
+	}
+}
+
+func TestBrowserNavigation_remembersFinalURLAfterRedirect(t *testing.T) {
+	var seen []seenNavigationHeaders
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/start" {
+			http.Redirect(w, r, "/landing", http.StatusFound)
+			return
+		}
+		seen = append(seen, seenNavigationHeaders{
+			Referer:      r.Header.Get("Referer"),
+			SecFetchSite: r.Header.Get("Sec-Fetch-Site"),
+		})
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(srv.URL),
+		httpx.WithBrowserNavigation(),
+	)
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().Get("/start"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Req().Get("/next"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(seen) != 2 {
+		t.Fatalf("non-redirect requests seen: want 2, got %d", len(seen))
+	}
+	wantReferer := srv.URL + "/landing"
+	if seen[1].Referer != wantReferer {
+		t.Fatalf("Referer: want %q, got %q", wantReferer, seen[1].Referer)
+	}
+}
+
+func TestBrowserNavigation_internalRequestKindMarkerDoesNotLeakWithNonCanonicalHeader(t *testing.T) {
+	rec := newNavigationRecorder(t)
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(rec.server.URL),
+		httpx.WithBrowserNavigation(),
+	)
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().
+		SetHeaderNonCanonical("x-httpx-browser-request-kind", "xhr").
+		Get("/api"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rec.seen) != 1 {
+		t.Fatalf("requests seen: want 1, got %d", len(rec.seen))
+	}
+	got := rec.seen[0]
+	if got.InternalRequestKind != "" {
+		t.Fatalf("internal request kind header leaked: got %q", got.InternalRequestKind)
+	}
+	if got.SecFetchMode != "cors" {
+		t.Fatalf("Sec-Fetch-Mode: want cors, got %q", got.SecFetchMode)
+	}
+	if got.SecFetchDest != "empty" {
+		t.Fatalf("Sec-Fetch-Dest: want empty, got %q", got.SecFetchDest)
+	}
+	if got.SecFetchUser != "" {
+		t.Fatalf("Sec-Fetch-User: want empty for XHR, got %q", got.SecFetchUser)
+	}
+	if got.UpgradeInsecureRequests != "" {
+		t.Fatalf("Upgrade-Insecure-Requests: want empty for XHR, got %q", got.UpgradeInsecureRequests)
+	}
+}
+
+func TestBrowserNavigation_retryPreservesPreviousURLAndRequestKind(t *testing.T) {
+	var retrySeen []seenNavigationHeaders
+	var otherSeen []seenNavigationHeaders
+	retryAttempts := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := seenNavigationHeaders{
+			Accept:                  r.Header.Get("Accept"),
+			Referer:                 r.Header.Get("Referer"),
+			Origin:                  r.Header.Get("Origin"),
+			SecFetchSite:            r.Header.Get("Sec-Fetch-Site"),
+			SecFetchMode:            r.Header.Get("Sec-Fetch-Mode"),
+			SecFetchDest:            r.Header.Get("Sec-Fetch-Dest"),
+			SecFetchUser:            r.Header.Get("Sec-Fetch-User"),
+			UpgradeInsecureRequests: r.Header.Get("Upgrade-Insecure-Requests"),
+			XRequestedWith:          r.Header.Get("X-Requested-With"),
+			InternalRequestKind:     r.Header.Get("X-Httpx-Browser-Request-Kind"),
+		}
+		if r.URL.Path == "/retry" {
+			retrySeen = append(retrySeen, h)
+			retryAttempts++
+			if retryAttempts == 1 {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		otherSeen = append(otherSeen, h)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	f := httpx.NewClientFactory()
+	f.RegisterProfile("browser",
+		httpx.WithBaseURL(srv.URL),
+		httpx.WithBrowserNavigation(),
+		httpx.WithRetry(httpx.RetryPolicy{
+			Enabled:    true,
+			MaxRetries: 1,
+			MinBackoff: time.Millisecond,
+			MaxBackoff: time.Millisecond,
+		}),
+	)
+	c := f.MustNewClient("browser")
+
+	if _, err := c.Req().Get("/before"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Req().AsXHR().Post("/retry"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(retrySeen) != 2 {
+		t.Fatalf("retry attempts seen: want 2, got %d", len(retrySeen))
+	}
+	if len(otherSeen) != 1 {
+		t.Fatalf("non-retry requests seen: want 1, got %d", len(otherSeen))
+	}
+	wantReferer := srv.URL + "/before"
+	for i, got := range retrySeen {
+		if got.SecFetchMode != "cors" {
+			t.Fatalf("attempt %d Sec-Fetch-Mode: want cors, got %q", i+1, got.SecFetchMode)
+		}
+		if got.SecFetchDest != "empty" {
+			t.Fatalf("attempt %d Sec-Fetch-Dest: want empty, got %q", i+1, got.SecFetchDest)
+		}
+		if got.SecFetchUser != "" {
+			t.Fatalf("attempt %d Sec-Fetch-User: want empty for XHR, got %q", i+1, got.SecFetchUser)
+		}
+		if got.UpgradeInsecureRequests != "" {
+			t.Fatalf("attempt %d Upgrade-Insecure-Requests: want empty for XHR, got %q", i+1, got.UpgradeInsecureRequests)
+		}
+		if got.Referer != wantReferer {
+			t.Fatalf("attempt %d Referer: want %q, got %q", i+1, wantReferer, got.Referer)
+		}
+	}
+}

--- a/httpx/client_options.go
+++ b/httpx/client_options.go
@@ -44,6 +44,8 @@ type clientRegisterOpts struct {
 	redirectPolicySet bool
 	redirectPolicies  []RedirectPolicy
 
+	browserNavigation *browserNavigationConfig
+
 	logDisabled  bool
 	clientLogger *slog.Logger
 	clientLogSet bool
@@ -81,6 +83,7 @@ func (o clientRegisterOpts) clone() clientRegisterOpts {
 	out.clientReqInterceptors = append([]ReqInterceptor(nil), o.clientReqInterceptors...)
 	out.clientRespInterceptors = append([]RespInterceptor(nil), o.clientRespInterceptors...)
 	out.redirectPolicies = append([]RedirectPolicy(nil), o.redirectPolicies...)
+	out.browserNavigation = o.browserNavigation.clone()
 	return out
 }
 

--- a/httpx/doc.go
+++ b/httpx/doc.go
@@ -2,8 +2,9 @@
 // named profiles, shared defaults, and fresh caller-owned clients created from those
 // profiles. Shared response/result and pagination value objects are provided by
 // package github.com/c1emon/gcommon/v2/vo. It also supports optional retry, rate
-// limiting (golang.org/x/time/rate), browser impersonation profiles, cookie jars,
-// redirect policies, and opt-in JSON envelope error handling via interceptors.Error.
+// limiting (golang.org/x/time/rate), browser impersonation profiles, browser
+// navigation headers, cookie jars, redirect policies, and opt-in JSON envelope
+// error handling via interceptors.Error.
 // Use [InitDefaultClientFactory] and [GetDefaultClientFactory] for a package-level
 // default [ClientFactory] when a single shared factory is enough.
 //
@@ -11,4 +12,8 @@
 // before user-defined request middleware. Response hooks run in registration order
 // after req's internal parsers. The business-error interceptor is registered only
 // when enabled with [WithGlobalBusinessError] or [WithBusinessError].
+//
+// Browser navigation captures request-explicit headers before req merges common
+// headers, then applies dynamic navigation headers in the client round-trip
+// wrapper after URL/body parsing.
 package httpx

--- a/httpx/factory.go
+++ b/httpx/factory.go
@@ -195,6 +195,10 @@ func (f *ClientFactory) buildReqClient(name string, o *clientRegisterOpts) *req.
 		wrapReq(ri)
 	}
 
+	if o.browserNavigation != nil {
+		installBrowserNavigation(c, o.browserNavigation)
+	}
+
 	if lg := o.effectiveLogger(f); lg != nil {
 		c.OnBeforeRequest(interceptors.RequestLogger(lg))
 	}


### PR DESCRIPTION
## Summary
- add `WithBrowserNavigation` for per-client browser navigation headers and state
- preserve request-explicit headers while allowing navigation to override profile/browser defaults
- cover NewClient isolation, Clone shared state, redirect final URL, retry rollback, marker cleanup, and docs

## Validation
- `go test ./httpx -run BrowserNavigation -count=1`
- `go test ./httpx -count=1`
- `go list ./... ./httpx/...`
- `go test ./... ./httpx/... -count=1`
- GitNexus `detect_changes(scope=staged)`: HIGH, expected because `buildReqClient` / `RegisterProfile` construction paths are affected and covered by tests
